### PR TITLE
fix(binary-builder): don't overwrite release

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -137,3 +137,11 @@ export async function resolveFile(file: string): Promise<string> {
   }
   return join(pkg, '../', file);
 }
+
+/**
+ * Stop processing for some time.
+ * @param milliseconds time to sleep
+ */
+export function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -176,4 +176,10 @@ describe('util', () => {
       expect(existsSync(file2)).toBe(false);
     });
   });
+
+  describe('sleep', () => {
+    it('works', async () => {
+      await expect(util.sleep(0)).toResolve();
+    });
+  });
 });


### PR DESCRIPTION
currently sometimes releases are overwritten, seems to be a change in github api. before it returned a 422 if the release exists.