### PR TITLE
feat(binary-builder)!: support optional distro

### DIFF
--- a/src/commands/binary/utils.ts
+++ b/src/commands/binary/utils.ts
@@ -45,15 +45,12 @@ export async function createBuilderImage(
   { buildArgs }: BinaryBuilderConfig
 ): Promise<void> {
   log('Creating builder image');
-  const args = [
-    'build',
-    '--load',
-    '-t',
-    'builder',
-    '--build-arg',
-    `DISTRO=${getDistro()}`,
-  ];
+  const args = ['build', '--load', '-t', 'builder'];
+  const distro = getDistro();
   const arch = getArch();
+  if (is.nonEmptyString(distro)) {
+    args.push('--build-arg', `DISTRO=${distro}`);
+  }
   if (is.nonEmptyString(arch)) {
     args.push('--platform', DockerPlatform[arch]);
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,8 +11,6 @@ import * as findUp from 'find-up';
 
 export type ExecOptions = _ExecOptions;
 
-const DEFAULT_DISTRO = 'focal';
-
 export async function exists(command: string): Promise<boolean> {
   try {
     await which(command, true);
@@ -79,7 +77,7 @@ export function getWorkspace(): string {
 }
 
 export function getDistro(): string {
-  return getEnv('DISTRO') || getEnv('FLAVOR') || DEFAULT_DISTRO;
+  return getEnv('DISTRO') || getEnv('FLAVOR');
 }
 
 export function getArch(): DockerArch {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -42,10 +42,15 @@ export function getBinaryName(
   version: string,
   sum?: boolean | undefined
 ): string {
+  const distro = getDistro();
   const arch = getArch();
   const ext = sum ? `.${sumType}` : '';
-  if (is.nonEmptyString(arch)) {
-    return `${cfg.image}-${version}-${getDistro()}-${arch}.tar.xz${ext}`;
+  let image = `${cfg.image}-${version}`;
+  if (is.nonEmptyString(distro)) {
+    image += `-${distro}`;
   }
-  return `${cfg.image}-${version}-${getDistro()}.tar.xz${ext}`;
+  if (is.nonEmptyString(arch)) {
+    image += `-${arch}`;
+  }
+  return `${image}.tar.xz${ext}`;
 }

--- a/test/commands/binary/__snapshots__/utils.spec.ts.snap
+++ b/test/commands/binary/__snapshots__/utils.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`commands/binary/utils createBuilderImage works with build args 1`] = `
     "-t",
     "builder",
     "--build-arg",
-    "DISTRO=undefined",
+    "DISTRO=focal",
     "--platform",
     "linux/arm64",
     "--build-arg=FLAVOR=focal",

--- a/test/commands/binary/utils.spec.ts
+++ b/test/commands/binary/utils.spec.ts
@@ -64,6 +64,7 @@ describe('commands/binary/utils', () => {
 
     it('works with build args', async () => {
       utils.getArch.mockReturnValueOnce('aarch64');
+      utils.getDistro.mockReturnValueOnce('focal');
       await createBuilderImage(
         '',
         partial<BinaryBuilderConfig>({ buildArgs: ['FLAVOR=focal'] })

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -100,7 +100,7 @@ describe('util', () => {
   });
 
   it('getDistro', () => {
-    expect(util.getDistro()).toBe('focal');
+    expect(util.getDistro()).toBe('');
   });
 
   it('getArch', () => {


### PR DESCRIPTION
```
BREAKING CHANGE: distro no longer falls back to `focal`
```