### PR TITLE
fix: install latest supported npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,2 @@
 save-exact = true
 save-prefix =
-
-# pnpm run settings
-# https://pnpm.io/cli/run
-shell-emulator = true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+# no packages yet
+packages: []
+
+# need to publish workspace root with correct version
+includeWorkspaceRoot: true
+
+ignoredBuiltDependencies:
+  - unrs-resolver
+
+strictPeerDependencies: true

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -84,7 +84,7 @@ runs:
         set -ex
         npm --version
         command -v npm
-        pnpm install -g npm
+        npm install -g npm
         npm --version
         command -v npm
 

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -80,7 +80,13 @@ runs:
       # Ensure npm 11.5.1 or later for trusted publishing
     - shell: bash
       if: inputs.node == 'true'
-      run: npm install -g npm@latest
+      run: |
+        set -ex
+        npm --version
+        command -v npm
+        pnpm install -g npm
+        npm --version
+        command -v npm
 
     - if: inputs.node == 'true' && env.CACHE_HIT != 'true'
       shell: bash


### PR DESCRIPTION
`npm install -g npm@latest` fails on older node (eg v18)